### PR TITLE
Fix terraform init bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Note :
 ```
 terraform init
 ```
-If you recieve errors regarding ** TLS HANDSHAKE ** error consider using [Shecan](https://shecan.ir/) to download AWS provider.
+If you recieve errors regarding **TLS HANDSHAKE** error consider using [Shecan](https://shecan.ir/) to download AWS provider.
 ## See the deployment plan and accept it by typing yes
 
 ``` 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Note :
 ```
 terraform init
 ```
-
+If you recieve errors regarding ** TLS HANDSHAKE ** error consider using [Shecan](https://shecan.ir/) to download AWS provider.
 ## See the deployment plan and accept it by typing yes
 
 ``` 


### PR DESCRIPTION
I tried to perform `terraform init`  to download the provider and got the error regarding TLS Handshake error.

I fixed it by using **shecan** and thought it might be helpful for others.