### PR TITLE
change localstack image to localstack/localstack for resloving error : connection refused 127.0.0.1:4566

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
-version: "3.8"
+version: "3.5"
 services:
    localstack:
-     image: localstack/localstack-full:latest
+     image: localstack/localstack
      container_name: localstack
      ports:
        - "127.0.0.1:4510-4559:4510-4559"  


### PR DESCRIPTION
hello 
if you use localstack/localstack-full:latest image , you get error and your localstack container does not go up , if check docker logs of localstack container you will see :
![docker error](https://github.com/devopshobbies/aws-localstack-lab/assets/42912741/9e2cc104-6003-4144-8836-8955adbedede)
so you need to change image source in docker-compose to run successfully container 