### PR TITLE
replaced the discontinued image, localstack/localstack-full:latest wi…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
    localstack:
-     image: localstack/localstack-full:latest
+     image: localstack/localstack:latest
      container_name: localstack
      ports:
        - "127.0.0.1:4510-4559:4510-4559"  


### PR DESCRIPTION
…th the official one.

I got this error while running the compose file, so I updated the file: It seems you are using a discontinued LocalStack Docker image
localstack        |   (localstack/localstack-light or localstack/localstack-full).
localstack        |   These images have been discontinued with the release of v2.
localstack        |   Please use localstack/localstack or localstack/localstack-pro instead.